### PR TITLE
bug and UI fixes

### DIFF
--- a/app/src/main/java/com/example/pineappleexpense/MainActivity.kt
+++ b/app/src/main/java/com/example/pineappleexpense/MainActivity.kt
@@ -274,7 +274,7 @@ fun MainScreen(navController: NavHostController, login: (()-> Unit) = {}, logout
             }
             composable(
                 route = "editExpense/{expenseId}",
-                arguments = listOf(navArgument("expenseId") { type = NavType.IntType })
+                arguments = listOf(navArgument("expenseId") { type = NavType.StringType })
             ) { backStackEntry ->
                 // Retrieve the expenseId from arguments
                 val expenseId = backStackEntry.arguments?.getString("expenseId") ?: return@composable

--- a/app/src/main/java/com/example/pineappleexpense/ui/components/ExpenseFields.kt
+++ b/app/src/main/java/com/example/pineappleexpense/ui/components/ExpenseFields.kt
@@ -350,7 +350,7 @@ fun commentBox(initialText: String? = null): String {
                 }
             }
         },
-        modifier = Modifier.width(400.dp).height(130.dp)
+        modifier = Modifier.width(400.dp).height(120.dp)
     )
     return comment
 }

--- a/app/src/main/java/com/example/pineappleexpense/ui/components/NavBars.kt
+++ b/app/src/main/java/com/example/pineappleexpense/ui/components/NavBars.kt
@@ -43,7 +43,7 @@ import com.example.pineappleexpense.ui.viewmodel.UserRole
 fun TopBar(navController: NavHostController, viewModel: AccessViewModel) {
     val currentRoute = navController.currentDestination?.route
     val pagesWithBackButton = setOf("Receipt Preview", "Settings", "Profile", "Admin Profile", "Account Mapping")
-    val currentRouteHasBackButton = (currentRoute in pagesWithBackButton || currentRoute?.startsWith("editExpense") == true || currentRoute?.startsWith("viewReport") == true)
+    val currentRouteHasBackButton = (currentRoute in pagesWithBackButton || currentRoute?.startsWith("editExpense") == true || currentRoute?.startsWith("viewReport") == true || currentRoute?.startsWith("adminViewReport") == true)
     val userState = viewModel.getCurrentRole()
 
     Box(

--- a/app/src/main/java/com/example/pineappleexpense/ui/components/ReportCardComponents.kt
+++ b/app/src/main/java/com/example/pineappleexpense/ui/components/ReportCardComponents.kt
@@ -109,7 +109,7 @@ fun ReportCard(
                     )
                     Spacer(modifier = Modifier.height(2.dp))
                     Text(
-                        text = "report: ${report.name}",
+                        text = dateRangeText,
                         style = MaterialTheme.typography.titleMedium,
                         fontWeight = FontWeight.Bold
                     )
@@ -118,12 +118,6 @@ fun ReportCard(
                         text = "Total: $${"%.2f".format(totalAmount)}",
                         style = MaterialTheme.typography.bodyMedium,
                         color = Color.Gray
-                    )
-                    Spacer(modifier = Modifier.height(2.dp))
-                    Text(
-                        text = dateRangeText,
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.secondary
                     )
                 }
             }
@@ -177,7 +171,7 @@ fun ReportCard(
                 // Report details
                 Column(modifier = Modifier.weight(1f)) {
                     Text(
-                        text = "report: ${report.name}",
+                        text = dateRangeText,
                         style = MaterialTheme.typography.titleMedium,
                         fontWeight = FontWeight.Bold
                     )
@@ -188,11 +182,6 @@ fun ReportCard(
                         color = Color.Gray
                     )
                     Spacer(modifier = Modifier.height(2.dp))
-                    Text(
-                        text = dateRangeText,
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.secondary
-                    )
                 }
             }
         }

--- a/app/src/main/java/com/example/pineappleexpense/ui/screens/AccountMapping.kt
+++ b/app/src/main/java/com/example/pineappleexpense/ui/screens/AccountMapping.kt
@@ -29,7 +29,7 @@ fun AccountMapping(navController: NavHostController, viewModel: AccessViewModel,
     var selectedCategory by remember { mutableStateOf("") }
     var selectedAccount by remember { mutableStateOf("") }
     
-    val categories = listOf("Meals", "Travel", "Supplies", "Safety", "Other")
+    val categories = listOf("Meals", "Travel", "Supplies", "Safety", "Lodging", "Other")
     val mappings = viewModel.accountMappings
 
     Scaffold(

--- a/app/src/main/java/com/example/pineappleexpense/ui/screens/EditExpense.kt
+++ b/app/src/main/java/com/example/pineappleexpense/ui/screens/EditExpense.kt
@@ -2,17 +2,19 @@ package com.example.pineappleexpense.ui.screens
 
 import android.annotation.SuppressLint
 import android.util.Log
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Scaffold
@@ -23,6 +25,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -30,19 +33,16 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
 import coil.compose.rememberImagePainter
-import com.example.pineappleexpense.model.Expense
 import com.example.pineappleexpense.ui.components.*
 import com.example.pineappleexpense.ui.components.BottomBar
 import com.example.pineappleexpense.ui.components.TopBar
 import com.example.pineappleexpense.ui.viewmodel.AccessViewModel
-import java.text.SimpleDateFormat
 import java.util.Date
-import java.util.Locale
 
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @Composable
 fun EditExpense(navController: NavHostController, viewModel: AccessViewModel, expenseID: String) {
-
+    val scrollState = rememberScrollState()
     val expense = viewModel.expenseList.value.find { it.id == expenseID }
 
     //navigate home if there is no expense with the passed in ID
@@ -74,7 +74,7 @@ fun EditExpense(navController: NavHostController, viewModel: AccessViewModel, ex
         }
     ) {
         Column (
-            modifier = Modifier.fillMaxSize(),
+            modifier = Modifier.fillMaxSize().verticalScroll(scrollState).padding(bottom = 125.dp),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             Image(
@@ -112,16 +112,23 @@ fun EditExpense(navController: NavHostController, viewModel: AccessViewModel, ex
                     //navigate back
                     navController.popBackStack()
                 },
-                colors = ButtonDefaults.buttonColors(containerColor = Color.Transparent),
-                shape = RoundedCornerShape(16.dp),
-                border = BorderStroke(1.dp, Color(0xFF6200EA)),
-                contentPadding = PaddingValues(horizontal = 8.dp, vertical = 0.dp),
-                modifier = Modifier.height(30.dp)
+                shape = RoundedCornerShape(50),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = Color(0xFFBB86FC),
+                    contentColor   = Color.White
+                ),
+                elevation = ButtonDefaults.buttonElevation(defaultElevation = 4.dp),
+                modifier = Modifier
+                    .wrapContentWidth()
+                    .height(40.dp)
+                    .padding(horizontal = 4.dp)
             ) {
                 Text(
-                    text = "save",
-                    color = Color(0xFF6200EA),
-                    fontSize = 12.sp
+                    text = "SAVE",
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 14.sp,
+                    letterSpacing = 1.sp,
+                    modifier = Modifier.padding(horizontal = 16.dp)
                 )
             }
         }

--- a/app/src/main/java/com/example/pineappleexpense/ui/screens/ReceiptPreview.kt
+++ b/app/src/main/java/com/example/pineappleexpense/ui/screens/ReceiptPreview.kt
@@ -10,8 +10,12 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Scaffold
@@ -20,7 +24,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -42,6 +48,8 @@ import java.util.Locale
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @Composable
 fun ReceiptPreview(navController: NavHostController, viewModel: AccessViewModel) {
+    val scrollState = rememberScrollState()
+
     val imageUri = viewModel.latestImageUri
     val prediction = viewModel.currentPrediction
     var category: String
@@ -61,7 +69,7 @@ fun ReceiptPreview(navController: NavHostController, viewModel: AccessViewModel)
         }
     ) {
         Column (
-            modifier = Modifier.fillMaxSize(),
+            modifier = Modifier.fillMaxSize().verticalScroll(scrollState).padding(bottom = 125.dp),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             Image(
@@ -90,7 +98,7 @@ fun ReceiptPreview(navController: NavHostController, viewModel: AccessViewModel)
                 onClick = {
                     //put the receipt information into an Expense object
                     //currently just gives default values if there is a parsing error, this will be changed to prompt the user in the future
-                    val receipt = Expense(title, total?:0f, date?:SimpleDateFormat("yyyy-MM-dd", Locale.getDefault()).parse("0000-00-00"), comment, category, imageUri)
+                    val receipt = Expense(title, total?:0f, date?:SimpleDateFormat("yyyy-MM-dd", Locale.getDefault()).parse("0000-00-00"), comment, category, imageUri, id = imageUri?.lastPathSegment.toString())
                     //add the receipt to the viewmodel
                     viewModel.addExpense(receipt)
                     //navigate back to home
@@ -99,16 +107,23 @@ fun ReceiptPreview(navController: NavHostController, viewModel: AccessViewModel)
                         restoreState = true
                     }
                 },
-                colors = ButtonDefaults.buttonColors(containerColor = Color.Transparent),
-                shape = RoundedCornerShape(16.dp),
-                border = BorderStroke(1.dp, Color(0xFF6200EA)),
-                contentPadding = PaddingValues(horizontal = 8.dp, vertical = 0.dp),
-                modifier = Modifier.height(30.dp)
+                shape = RoundedCornerShape(50),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = Color(0xFFBB86FC),
+                    contentColor   = Color.White
+                ),
+                elevation = ButtonDefaults.buttonElevation(defaultElevation = 4.dp),
+                modifier = Modifier
+                    .wrapContentWidth()
+                    .height(40.dp)
+                    .padding(horizontal = 4.dp)
             ) {
                 Text(
-                    text = "done",
-                    color = Color(0xFF6200EA),
-                    fontSize = 12.sp
+                    text = "DONE",
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 14.sp,
+                    letterSpacing = 1.sp,
+                    modifier = Modifier.padding(horizontal = 16.dp)
                 )
             }
         }

--- a/app/src/main/java/com/example/pineappleexpense/ui/viewmodel/AccessViewModel.kt
+++ b/app/src/main/java/com/example/pineappleexpense/ui/viewmodel/AccessViewModel.kt
@@ -276,14 +276,9 @@ class AccessViewModel(application: Application): AndroidViewModel(application) {
                                     onSuccess = {
                                         Log.d(TAG, "✔ submitReportRemote success")
 
-                                        // ── 4) Mirror to local DB (IO) & finish ──
-                                        val timestamp = SimpleDateFormat(
-                                            "yyyyMMdd_HHmmss",
-                                            Locale.getDefault()
-                                        ).format(Date())
-
                                         val newReport = Report(
-                                            name       = timestamp,
+                                            id = remoteId,
+                                            name       = remoteId,
                                             expenseIds = current.expenseIds,
                                             status     = "Under Review",
                                             userName   = manager.getName().orEmpty()
@@ -292,7 +287,7 @@ class AccessViewModel(application: Application): AndroidViewModel(application) {
                                         viewModelScope.launch(Dispatchers.IO) {
                                             reportDao.insertReport(newReport)
                                             reportDao.updateExpensesForReport("current", emptyList())
-                                            Log.d(TAG, "✔ Local DB updated – new report '$timestamp'")
+                                            Log.d(TAG, "✔ Local DB updated – new report '$remoteId'")
                                             loadReports()
                                             complete(true)     // SUCCESS ✅
                                         }


### PR DESCRIPTION
- fixed edit button crash
- made receipt preview page scrollable so done button is easier to press on smaller screens
- also make done button look better ^
- same stuff for edit expense page
- fixed back button not appearing when viewing a report as an admin
- made report names not show, they should be distinguishable by date range and user name
- fixed a bug where submitting a report and then refreshing as an admin downloads another copy of the report and duplicates expenses