### PR TITLE
made deleted report on cloud update locally

### DIFF
--- a/app/src/main/java/com/example/pineappleexpense/ui/components/ExpenseCardComponents.kt
+++ b/app/src/main/java/com/example/pineappleexpense/ui/components/ExpenseCardComponents.kt
@@ -283,27 +283,18 @@ fun ExpandedExpenseCard(
             verticalAlignment = Alignment.CenterVertically
         ) {
             if (inReport) {
-                if (viewModel.currentReportExpenses.value.contains(expense)
-                    || viewModel.pendingExpenses.contains(expense)) {
+                if (viewModel.currentReportExpenses.value.contains(expense)) {
                     Button(
                         onClick = onRemoveFromReportClicked,
                         modifier = Modifier.weight(1f),
                         colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.secondary),
                         shape = RoundedCornerShape(12.dp)
                     ) {
-                        if (viewModel.currentReportExpenses.value.contains(expense)) {
-                            Text(
-                                text = "Remove from Current Report",
-                                style = MaterialTheme.typography.bodyMedium,
-                                color = MaterialTheme.colorScheme.onPrimary
-                            )
-                        } else {
-                            Text(
-                                text = "Remove from Report",
-                                style = MaterialTheme.typography.bodyMedium,
-                                color = MaterialTheme.colorScheme.onPrimary
-                            )
-                        }
+                        Text(
+                            text = "Remove from Current Report",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onPrimary
+                        )
                     }
                 }
             } else {


### PR DESCRIPTION
- made local reports delete in the case of a different user deleting the report by making fetchpendingreports delete all local pending reports before downloading
- fetch pending reports now first updates any accepted or rejected reports, and deletes any local rejected reports that were deleted on the cloud (by checking if each local rejected report exists in the report updates passed back)
- fixed expenses having remove from report button on pending reports